### PR TITLE
minor bug fixes

### DIFF
--- a/machine-learning-reference/notebooks/.ipynb_checkpoints/02-mobilenet-transfer-learning-checkpoint.ipynb
+++ b/machine-learning-reference/notebooks/.ipynb_checkpoints/02-mobilenet-transfer-learning-checkpoint.ipynb
@@ -5247,7 +5247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trained_model_path = \"models/mobilenet-orig\""
+    "trained_model_path = \"models/mobilenet-orig/\""
    ]
   },
   {
@@ -5493,9 +5493,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "iotedge",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "iotedge"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -5507,7 +5507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/machine-learning-reference/notebooks/02-mobilenet-transfer-learning.ipynb
+++ b/machine-learning-reference/notebooks/02-mobilenet-transfer-learning.ipynb
@@ -5247,7 +5247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trained_model_path = \"models/mobilenet-orig\""
+    "trained_model_path = \"models/mobilenet-orig/\""
    ]
   },
   {
@@ -5493,9 +5493,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "iotedge",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "iotedge"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -5507,7 +5507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/machine-learning-reference/notebooks/utility.py
+++ b/machine-learning-reference/notebooks/utility.py
@@ -54,7 +54,7 @@ def transferdlc(model_name = None):
 
         # find root folders
         dirpath = os.getcwd()
-        src = os.path.join(dirpath,"var","azureml-app","azureml-models", model_path)
+        src = os.path.join(dirpath,"azureml-models", model_path)
         dst = os.path.abspath("/app/vam_model_folder")
 
         # find model files


### PR DESCRIPTION
I made a couple of minor bug fixes as proposed by @sunnypshsu. 

1.	The first bug is caused by “src” setting in “utility.py” line 57:

                   src = os.path.join(dirpath,"var","azureml-app","azureml-models", model_path)

                   And it should be changed to be:

                   src = os.path.join(dirpath,"azureml-models", model_path)

2.	The second bug is caused by it lacking a ‘/’ at the end of subfolder end in 02-mobilenet-transfer-learning.ipynb, and it can be fixed by changing the following wrong code to be 'trained_model_path = "models/mobilenet-orig/"'

