### PR TITLE
Update Dockerfile.amd64.debug

### DIFF
--- a/samples/official/ai-vision-devkit-get-started/modules/WebStreamModule/Dockerfile.amd64.debug
+++ b/samples/official/ai-vision-devkit-get-started/modules/WebStreamModule/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8-slim
 
 WORKDIR /app/RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The image node:8-alpine doesn't have apt-get, if we use node:8-slim it doesn't fail