### PR TITLE
Update Dockerfile.amd64

### DIFF
--- a/samples/official/ai-vision-devkit-get-started/modules/WebStreamModule/Dockerfile.amd64
+++ b/samples/official/ai-vision-devkit-get-started/modules/WebStreamModule/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8-slim
 
 WORKDIR /app/
 


### PR DESCRIPTION
The image node:8-alpine doesn't have apt-get, if we use node:8-slim it doesn't fail