### PR TITLE
Update to use prebuilt vision sample

### DIFF
--- a/samples/official/camera-tagging/deployment.template.json
+++ b/samples/official/camera-tagging/deployment.template.json
@@ -127,7 +127,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "${MODULES.VisionSampleModule}",
+              "image": "mcr.microsoft.com/aivision/visionsamplemodule:1.1.3-arm32v7",
               "createOptions": {
                 "HostConfig": {
                   "Binds": [


### PR DESCRIPTION
Update camera-tagging deployment to use prebuilt Vision Sample image