### PR TITLE
Bump mixin-deep from 1.3.1 to 1.3.2

### DIFF
--- a/samples/official/camera-tagging/modules/CameraTaggingModule/CameraClientModule/yarn.lock
+++ b/samples/official/camera-tagging/modules/CameraTaggingModule/CameraClientModule/yarn.lock
@@ -6307,9 +6307,9 @@ mississippi@^3.0.0:
     through2 "^2.0.0"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"


### PR DESCRIPTION
Manual update for: Bump mixin-deep from 1.3.1 to 1.3.2 in /samples/official/camera-tagging/modules/CameraTaggingModule/Arm32Base/TaggingClientDocker #253

File location was changed to streamline the install process in:
https://github.com/microsoft/vision-ai-developer-kit/pull/293 

New file location is:
samples/official/camera-tagging/modules/CameraTaggingModule/CameraClientModule/yarn.lock

It has been updated in this PR with the requested change in #253 at the new location.  
