### PR TITLE
fix problem with package_data

### DIFF
--- a/camera-sdk/setup.py
+++ b/camera-sdk/setup.py
@@ -58,7 +58,7 @@ setup_args = {
         DEPENDENCIES
     ],
     'packages': _packages,
-    'package_data': {'sdk': 'logger.conf'},
+    'package_data': {'sdk': ['logger.conf']},
     'zip_safe': False,
     'cmdclass': {
     },


### PR DESCRIPTION
package_data property in master is wrong and prevents package installation. package_data dict must be a list of strings, not an individual string.